### PR TITLE
Added BOC to message and transaction models

### DIFF
--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -669,6 +669,14 @@ impl TryFrom<(UInt256, ton_block::Transaction)> for Transaction {
         };
 
         let total_fees = compute_total_transaction_fees(&data, &desc) as u64;
+        let boc = data
+            .write_to_new_cell()
+            .map_err(|_| TransactionError::InvalidStructure)?;
+        let boc = boc
+            .into_cell()
+            .map_err(|_| TransactionError::InvalidStructure)?;
+        let boc = ton_types::serialize_toc(&boc).map_err(|_| TransactionError::InvalidStructure)?;
+        let boc = base64::encode(boc);
 
         let in_msg = match data.in_msg.take() {
             Some(message) => {
@@ -702,14 +710,6 @@ impl TryFrom<(UInt256, ton_block::Transaction)> for Transaction {
                 Ok(true)
             })
             .map_err(|_| TransactionError::InvalidStructure)?;
-        let boc = data
-            .write_to_new_cell()
-            .map_err(|_| TransactionError::InvalidStructure)?;
-        let boc = boc
-            .into_cell()
-            .map_err(|_| TransactionError::InvalidStructure)?;
-        let boc = ton_types::serialize_toc(&boc).map_err(|_| TransactionError::InvalidStructure)?;
-        let boc = base64::encode(boc);
 
         Ok(Self {
             id: TransactionId { lt: data.lt, hash },

--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -842,7 +842,7 @@ impl<'de> Deserialize<'de> for Message {
 }
 
 impl Serialize for Message {
-    fn serialize<S>(&self, serializer: S) -> std::prelude::v1::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -868,6 +868,7 @@ impl Serialize for Message {
             bounced: bool,
             body: Option<String>,
             body_hash: Option<String>,
+            boc: &'a str,
         }
 
         let (body, body_hash) = match &self.body {
@@ -887,6 +888,7 @@ impl Serialize for Message {
             bounced: self.bounced,
             body,
             body_hash,
+            boc: &self.boc,
         }
         .serialize(serializer)
     }

--- a/src/crypto/derived_key/mod.rs
+++ b/src/crypto/derived_key/mod.rs
@@ -211,7 +211,7 @@ impl StoreSigner for DerivedKeySigner {
                     None => return Err(MasterKeyError::MasterKeyNotFound.into()),
                 };
 
-                let mut entry = match entry.accounts_map.get_mut(public_key.as_bytes()) {
+                let entry = match entry.accounts_map.get_mut(public_key.as_bytes()) {
                     Some(entry) => entry,
                     None => return Err(MasterKeyError::DerivedKeyNotFound.into()),
                 };


### PR DESCRIPTION
Due to the absence of BOC field in the models, the developer loses most of the transaction/message data. After adding of BOC field, it will be enough to write a tx/msg parser and get any necessary information without further extension of the models.